### PR TITLE
Add support for non-quadratic whiteout-shapes (box and rounded-box style whiteout only)

### DIFF
--- a/lily/grob.cc
+++ b/lily/grob.cc
@@ -147,7 +147,7 @@ Grob::get_print_stencil () const
       /* A grob has to be visible, otherwise the whiteout property has no effect. */
       /* Calls the scheme procedure stencil-whiteout in scm/stencils.scm */
       if (!transparent && (scm_is_number (get_property ("whiteout"))
-                           || scm_is_pair (get_property ("whiteout"))  /* We actually would need number-pair */
+                           || is_number_pair (get_property ("whiteout"))
                            || to_boolean (get_property ("whiteout"))))
         {
           Real line_thickness = layout ()->get_dimension (ly_symbol2scm ("line-thickness"));

--- a/lily/grob.cc
+++ b/lily/grob.cc
@@ -147,6 +147,7 @@ Grob::get_print_stencil () const
       /* A grob has to be visible, otherwise the whiteout property has no effect. */
       /* Calls the scheme procedure stencil-whiteout in scm/stencils.scm */
       if (!transparent && (scm_is_number (get_property ("whiteout"))
+                           || scm_is_pair (get_property ("whiteout"))  /* We actually would need number-pair */
                            || to_boolean (get_property ("whiteout"))))
         {
           Real line_thickness = layout ()->get_dimension (ly_symbol2scm ("line-thickness"));

--- a/scm/c++.scm
+++ b/scm/c++.scm
@@ -57,6 +57,9 @@
 (define-public (boolean-or-number? x)
   (or (boolean? x) (number? x)))
 
+(define-public (boolean-or-number-or-number-pair? x)
+ (or (boolean? x) (number? x) (number-pair? x)))
+
 (define-public (boolean-or-symbol? x)
   (or (boolean? x) (symbol? x)))
 

--- a/scm/define-grob-properties.scm
+++ b/scm/define-grob-properties.scm
@@ -1168,15 +1168,16 @@ one below this grob.")
 ;;; w
 ;;;
      (when ,ly:moment? "Global time step associated with this column.")
-     (whiteout ,boolean-or-number? "If a number or true, the grob is
-printed over a white background to white-out underlying material, if
+     (whiteout ,boolean-or-number-or-number-pair? "If a number, number-pair
+     or true, the grob is printed over a white background to white-out underlying material, if
 the grob is visible.  A number indicates how far the white background
 extends beyond the bounding box of the grob as a multiple of the
-staff-line thickness.  The @code{LyricHyphen} grob uses a special
+staff-line thickness.  A number pair is interpreted as giving
+X- and Y-extent separately. The @code{LyricHyphen} grob uses a special
 implementation of whiteout:  A positive number indicates how far the
 white background extends beyond the bounding box in multiples of
 @code{line-thickness}.  The shape of the background is determined by
-@code{whiteout-style}.  Usually @code{#f} by default. ")
+@code{whiteout-style}. Usually @code{#f} by default. ")
      (whiteout-style ,symbol? "Determines the shape of the
 @code{whiteout} background.  Available are @code{'outline},
 @code{'rounded-box}, and the default @code{'box}.  There is one

--- a/scm/define-grob-properties.scm
+++ b/scm/define-grob-properties.scm
@@ -1168,16 +1168,17 @@ one below this grob.")
 ;;; w
 ;;;
      (when ,ly:moment? "Global time step associated with this column.")
-     (whiteout ,boolean-or-number-or-number-pair? "If a number, number-pair
-     or true, the grob is printed over a white background to white-out underlying material, if
-the grob is visible.  A number indicates how far the white background
-extends beyond the bounding box of the grob as a multiple of the
-staff-line thickness.  A number pair is interpreted as giving
-X- and Y-extent separately. The @code{LyricHyphen} grob uses a special
-implementation of whiteout:  A positive number indicates how far the
-white background extends beyond the bounding box in multiples of
-@code{line-thickness}.  The shape of the background is determined by
-@code{whiteout-style}. Usually @code{#f} by default. ")
+     (whiteout ,boolean-or-number-or-number-pair? "If a number,
+number-pair or true, the grob is printed over a white background to
+white-out underlying material, if the grob is visible.  A number
+indicates how far the white background extends beyond the bounding 
+box of the grob as a multiple of the staff-line thickness.  A number
+pair is interpreted as giving X- and Y-extent separately.  The
+@code{LyricHyphen} grob uses a special implementation of whiteout:  
+A positive number indicates how far the white background extends
+beyond the bounding box in multiples of @code{line-thickness}.  
+The shape of the background is determined by @code{whiteout-style}.  
+Usually @code{#f} by default. ")
      (whiteout-style ,symbol? "Determines the shape of the
 @code{whiteout} background.  Available are @code{'outline},
 @code{'rounded-box}, and the default @code{'box}.  There is one


### PR DESCRIPTION

       modified:               lily/grob.cc
       modified:               scm/c++.scm
       modified:               scm/define-grob-properties.scm
       modified:               scm/stencil.scm