### PR TITLE
WIP: Limit angle of broken hairpins

### DIFF
--- a/lily/hairpin.cc
+++ b/lily/hairpin.cc
@@ -271,15 +271,18 @@ Hairpin::print (SCM smob)
 
   Real starth = 0;
   Real endh = 0;
+  Real max_ratio = width / 2
+  Real continued_height = height / 3
+  Real continuing_height = 2 * height / 3
   if (grow_dir < 0)
     {
-      starth = continuing ? 2 * height / 3 : height;
-      endh = continued ? height / 3 : 0.0;
+      starth = continuing ? std::min(continuing_height, max_ratio) : height;
+      endh = continued ? std::max(continued_height, height - max_ratio) : 0.0;
     }
   else
     {
-      starth = continued ? height / 3 : 0.0;
-      endh = continuing ? 2 * height / 3 : height;
+      starth = continued ? std::max(continued_height, height - max_ratio) : 0.0;
+      endh = continuing ? std::min(continuing_height, max_ratio) : height;
     }
 
   /*


### PR DESCRIPTION
**PLEASE DON'T MERGE, only for discussion**

Broken parts of hairpins don't look good when they are too short. This is because their height at the broken side is hard-coded to 2/3 and 1/3 of the hairpin's height. So when the sibling's width is small the ratio/angle is too high to be visually pleasing.

This commit (initial thoughts) limits the width/height ratio of broken hairpins to 1/2.

It would be good to provide both the broken-heights and the ratio as native grob properties for Hairpin, though.

Wouldn't it be good to (additionally?) have a propert that makes the hairpin print just like an unbroken hairpin cut in two? That means having the angle of all siblings identical?