### PR TITLE
Corrected program hanging on command line call

### DIFF
--- a/python/book_latex.py
+++ b/python/book_latex.py
@@ -189,7 +189,7 @@ def get_latex_textwidth (source, global_options):
 
     progress (_ ("Running `%s' on file `%s' to detect default page settings.\n")
               % (global_options.latex_program, tmpfile))
-    cmd = '%s %s' % (global_options.latex_program, tmpfile)
+    cmd = '%s -interaction=nonstopmode %s' % (global_options.latex_program, tmpfile)
     debug ("Executing: %s\n" % cmd)
     run_env = os.environ.copy()
     run_env['LC_ALL'] = 'C'


### PR DESCRIPTION
`lilypond-book.py` hangs whenever there's a problem calling the LaTeX command because LaTeX stops and waits for input whenever it has an error, but the user is unable to provide input when it's Python calling LaTeX. Changing the call to nonstopmode allows `lilypond-book.py` to at least abort unsuccessfully rather than freezing indefinitely.