### PR TITLE
Fix integer division in midi2ly

### DIFF
--- a/scripts/midi2ly.py
+++ b/scripts/midi2ly.py
@@ -201,7 +201,7 @@ class Note:
         #
         #  --jcn
 
-        o = self.pitch / 12 - 4
+        o = self.pitch // 12 - 4
 
         if key.minor:
             # as -> gis


### PR DESCRIPTION
In Python 3 integer divisions need a double slash.