### PR TITLE
Proposed patch: add ability to set two sided 'flipped'

### DIFF
--- a/ly/paper-defaults-init.ly
+++ b/ly/paper-defaults-init.ly
@@ -99,6 +99,7 @@
   %% Two-sided mode
   %%
   two-sided = ##f
+  two-sided-flipped = ##f
   inner-margin-default = 15\mm   % scaled to paper-size
   outer-margin-default = 15\mm   % scaled to paper-size
   binding-offset-default = 5\mm  % scaled to paper-size

--- a/scm/page.scm
+++ b/scm/page.scm
@@ -270,12 +270,19 @@ of layout settings just like markups inside the music."
                          (- (car (ly:stencil-extent foot Y)))))))))
 
     (if (ly:output-def-lookup layout 'two-sided #f)
-        (set! page-stencil
-              (ly:stencil-translate page-stencil
-                                    (cons (prop (if (even? number)
-                                                    'left-margin
-                                                    'right-margin))
-                                          0)))
+      (if (ly:output-def-lookup layout 'two-sided-flipped #f)
+          (set! page-stencil
+                (ly:stencil-translate page-stencil
+                                      (cons (prop (if (odd? number)
+                                                      'left-margin
+                                                      'right-margin))
+                                            0)))
+          (set! page-stencil
+                (ly:stencil-translate page-stencil
+                                      (cons (prop (if (even? number)
+                                                      'left-margin
+                                                      'right-margin))
+                                            0))))
         (set! page-stencil
               (ly:stencil-translate page-stencil (cons (prop 'left-margin) 0))))
 


### PR DESCRIPTION
When setting music for my choir, I run into the inner/outer margins for the ``two-sided`` opion to be just the wrong way around for perforating holes in the paper and putting them into a binder.

Having to manually 'flip' the inner- and outer margin is cumbersome when you want to apply the default, but 'the other way around'.

This proposed patch adds the functionality to add this into your .ly file:

```
\paper {
  #(set-paper-size "a4")
  two-sided = ##t
  two-sided-flipped = ##t
  %auto-first-page-number = ##t
  %outer-margin = 8
  %inner-margin = 18
}
```

That way, the margins are automaticaly flipped with respect to the page number being odd or even.

I haven't documented this variable yet, because I couldn't find the correct place in the documentation to add it... so if someone could point me to the correct file in the repo, that'd. be nice.

Any comments on this? Should I add tests? Is it possible to test this behavour?

Christ van Willegen